### PR TITLE
Support destroy. Closes #28.

### DIFF
--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -265,6 +265,7 @@ $host.mag({
               <button class="mag-eg-ctrl-move-left" mag-ctrl-move-by-x="-0.5">&lt;</button>
               <button class="mag-eg-ctrl-move-right" mag-ctrl-move-by-x="0.5">&gt;</button>
               <button class="mag-eg-ctrl-fullscreen" mag-ctrl-fullscreen>[ ]</button>
+              <button class="mag-eg-ctrl-destroy" mag-ctrl-destroy>destroy</button>
             </div>
           </div>
           <div class="col col-md-6">
@@ -288,6 +289,7 @@ $host.mag({
   &lt;button mag-ctrl-move-by-x=&quot;-0.5&quot;&gt;&lt;&lt;/button&gt;
   &lt;button mag-ctrl-move-by-x=&quot;0.5&quot;&gt;&gt;&lt;/button&gt;
   &lt;button mag-ctrl-fullscreen&gt;[ ]&lt;/button&gt;
+  &lt;button mag-ctrl-destroy&gt;destroy&lt;/button&gt;
 &lt;/div&gt;<!--
               --></code></pre>
               <pre><code class="lang-js"><!--

--- a/src/js/mag-control.js
+++ b/src/js/mag-control.js
@@ -58,6 +58,10 @@
         }
       }
     });
+
+    $el.find('[mag-ctrl-destroy]').on('click', function () {
+      magInst.destroy();
+    });
   };
 
 

--- a/src/js/mag-jquery.js
+++ b/src/js/mag-jquery.js
@@ -239,7 +239,8 @@
     toggle: true,
     smooth: true,
     cssMode: '3d',
-    eventNamespace: 'magnificent'
+    eventNamespace: 'magnificent',
+    dataNamespace: 'magnificent'
   };
 
 
@@ -291,9 +292,15 @@
   };
 
 
-  Magnificent.prototype.eventName = function (eventName) {
-    var eventNamespace = this.options.eventNamespace;
-    return eventName + (eventNamespace ? '.' + eventNamespace : '');
+  Magnificent.prototype.eventName = function (name) {
+    var namespace = this.options.eventNamespace;
+    return name + (namespace ? ('.' + namespace) : '');
+  };
+
+
+  Magnificent.prototype.dataName = function (name) {
+    var namespace = this.options.dataNamespace;
+    return (namespace ? (namespace + '.') : '') + name;
   };
 
 
@@ -754,8 +761,12 @@
 
       if (Hammer) {
         var hammerEl = zone;
+        var $hammerEl = $zone;
         var hammerOptions = {};
         var hammertime = new Hammer(hammerEl, hammerOptions);
+
+        $hammerEl.data(that.dataName('hammer'));
+
         hammertime.get('pinch').set({ enable: true });
 
         // console.log('options.pos', options.position);

--- a/src/js/mag-jquery.js
+++ b/src/js/mag-jquery.js
@@ -761,7 +761,7 @@
         // console.log('options.pos', options.position);
         // if (options.position === 'mirror') {
         if (options.mode === 'inner') {
-          hammertime.on(that.eventName('pan'), function (e) {
+          hammertime.on('pan', function (e) {
             e.preventDefault();
             // console.log('pan', e);
 
@@ -774,7 +774,7 @@
           });
         }
 
-        hammertime.on(that.eventName('pinch'), function(e) {
+        hammertime.on('pinch', function(e) {
           e.preventDefault();
           // console.log('pinch', e);
 

--- a/src/js/mag-jquery.js
+++ b/src/js/mag-jquery.js
@@ -238,7 +238,8 @@
     ratio: 1,
     toggle: true,
     smooth: true,
-    cssMode: '3d'
+    cssMode: '3d',
+    eventNamespace: 'magnificent'
   };
 
 
@@ -287,6 +288,12 @@
     $zoomed.css(zoomedCSS);
 
     this.$el.trigger('render', that);
+  };
+
+
+  Magnificent.prototype.eventName = function (eventName) {
+    var eventNamespace = this.options.eventNamespace;
+    return eventName + (eventNamespace ? '.' + eventNamespace : '');
   };
 
 
@@ -486,11 +493,11 @@
         throw new Error("Invalid 'initialShow' option.");
       }
 
-      $el.on('mouseenter', function () {
+      $el.on(that.eventName('mouseenter'), function () {
         that.toggle.call(that, true);
       });
 
-      $el.on('mouseleave', function () {
+      $el.on(that.eventName('mouseleave'), function () {
         that.toggle.call(that, false);
       });
     }
@@ -546,7 +553,7 @@
       if (options.positionEvent === 'move') {
         lazyRate = 0.2;
 
-        $zone.on('mousemove', function(e){
+        $zone.on(that.eventName('mousemove'), function(e){
           var ratios = ratioOffsets(e);
           adjustForMirror(ratios);
         });
@@ -641,7 +648,7 @@
           that.compute();
         });
 
-        $zone.on('click', function (e) {
+        $zone.on(that.eventName('click'), function (e) {
           var offset = $zone.offset();
           ratios = ratioOffsetsFor($zone, e.pageX - offset.left, e.pageY - offset.top);
 
@@ -672,7 +679,7 @@
         dragging = true;
         lazyRate = 0.5;
 
-        $zone.on('mousemove', function(e){
+        $zone.on(that.eventName('mousemove'), function(e){
           ratios = ratioOffsets(e);
         });
       }
@@ -720,7 +727,7 @@
 
 
     if (options.position) {
-      $zone.on('mousewheel', function (e) {
+      $zone.on(that.eventName('mousewheel'), function (e) {
         // console.log('mousewheel', {
         //   deltaX: e.deltaX,
         //   deltaY: e.deltaY,
@@ -754,7 +761,7 @@
         // console.log('options.pos', options.position);
         // if (options.position === 'mirror') {
         if (options.mode === 'inner') {
-          hammertime.on('pan', function (e) {
+          hammertime.on(that.eventName('pan'), function (e) {
             e.preventDefault();
             // console.log('pan', e);
 
@@ -767,7 +774,7 @@
           });
         }
 
-        hammertime.on('pinch', function(e) {
+        hammertime.on(that.eventName('pinch'), function(e) {
           e.preventDefault();
           // console.log('pinch', e);
 


### PR DESCRIPTION
Support destroy. Closes #28.

Adds a destroy method which will unbind events and restore original DOM.

Use as follows:
```js
$host.mag('destroy');
```

Pending official documentation.
