### PR TITLE
Use jQuery instead of $ shortcut for improved compatibility

### DIFF
--- a/src/js/mag-control.js
+++ b/src/js/mag-control.js
@@ -1,13 +1,13 @@
 (function (root, factory) {
   var name = 'MagnificentControl';
   if (typeof define === 'function' && define.amd) {
-    define(['jquery', './mag-analytics', 'jquery-bridget'], function ($, MagnificentAnalytics) {
-        return (root[name] = factory($, MagnificentAnalytics));
+    define(['jquery', './mag-analytics', 'jquery-bridget'], function (jQuery, MagnificentAnalytics) {
+        return (root[name] = factory(jQuery, MagnificentAnalytics));
     });
   } else if (typeof exports === 'object') {
     module.exports = factory(require('jquery'), require('./mag-analytics'), require('jquery-bridget'));
   } else {
-    root[name] = factory(root.$, root.MagnificentAnalytics);
+    root[name] = factory(root.jQuery, root.MagnificentAnalytics);
   }
 }(this, function ($, MagnificentAnalytics) {
 

--- a/src/js/mag-jquery.js
+++ b/src/js/mag-jquery.js
@@ -18,7 +18,7 @@
   var name = 'Magnificent';
   if (typeof define === 'function' && define.amd) {
     define(['./mag', './mag-analytics', 'jquery', 'hammerjs', 'prevent-ghost-click', 'jquery-bridget'],
-      function (mag, MagnificentAnalytics, $, Hammer) {
+      function (mag, MagnificentAnalytics, jQuery, Hammer) {
         return (root[name] = factory(mag, MagnificentAnalytics, jQuery, Hammer, PreventGhostClick));
       }
     );

--- a/src/js/mag-jquery.js
+++ b/src/js/mag-jquery.js
@@ -19,7 +19,7 @@
   if (typeof define === 'function' && define.amd) {
     define(['./mag', './mag-analytics', 'jquery', 'hammerjs', 'prevent-ghost-click', 'jquery-bridget'],
       function (mag, MagnificentAnalytics, $, Hammer) {
-        return (root[name] = factory(mag, MagnificentAnalytics, $, Hammer, PreventGhostClick));
+        return (root[name] = factory(mag, MagnificentAnalytics, jQuery, Hammer, PreventGhostClick));
       }
     );
   } else if (typeof exports === 'object') {
@@ -29,7 +29,7 @@
     );
   } else {
     root[name] = factory(root.Mag, root.MagnificentAnalytics,
-      root.$, root.Hammer, root.PreventGhostClick
+      root.jQuery, root.Hammer, root.PreventGhostClick
     );
   }
 }(this, function (Mag, MagnificentAnalytics, $, Hammer) {


### PR DESCRIPTION
I'm using this library with Drupal 7, and the `$` shortcut is not always available. Using `jQuery` directly allows this plugin to run in that environment with minimal changes to the code.

This fixes the following error:

```
Uncaught TypeError: $ is not a function    mag-jquery.js?v=2.1.4:38
```